### PR TITLE
Fix netavark compilation issues on FreeBSD #1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-route"
-version = "0.19.0"
+version = "0.19.1"
 edition = "2021"
 
 homepage = "https://github.com/rust-netlink/netlink-packet-route"

--- a/src/address_family_freebsd.rs
+++ b/src/address_family_freebsd.rs
@@ -35,6 +35,7 @@ pub enum AddressFamily {
     Natm,
     Atm,
     Netgraph,
+    Bridge,
     Other(u8),
 }
 
@@ -72,6 +73,7 @@ impl From<u8> for AddressFamily {
             d if d == libc::AF_NATM as u8 => Self::Natm,
             d if d == libc::AF_ATM as u8 => Self::Atm,
             d if d == libc::AF_NETGRAPH as u8 => Self::Netgraph,
+            d if d == libc::AF_BRIDGE as u8 => Self::Bridge,
             _ => Self::Other(d),
         }
     }
@@ -111,6 +113,7 @@ impl From<AddressFamily> for u8 {
             AddressFamily::Natm => libc::AF_NATM as u8,
             AddressFamily::Atm => libc::AF_ATM as u8,
             AddressFamily::Netgraph => libc::AF_NETGRAPH as u8,
+            AddressFamily::Bridge => libc::AF_BRIDGE as u8,
             AddressFamily::Other(d) => d,
         }
     }


### PR DESCRIPTION
- Add rtnetlink AF_BRIDGE
- Required for adding limited support for netlink on FreeBSD 13 and later, initially aiming to support functionality required by the netavark container networking manager
- Required to build netavark's nispor dependency

